### PR TITLE
Added an Option to replicate Nodes as "hidden" Nodes

### DIFF
--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -20,7 +20,8 @@ class NodeSignalInterceptor
     public static function nodeAdded(NodeInterface $node)
     {
         if (self::hasReplicationConfiguration($node) && self::nodeReplicationEnabled($node)) {
-                self::getNodeReplicator()->replicateNode($node, self::nodeCreateHiddenEnabled($node));
+            self::getNodeReplicator()->replicateNode($node, self::nodeCreateHiddenEnabled($node));
+        }
     }
 
     /**

--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -20,12 +20,7 @@ class NodeSignalInterceptor
     public static function nodeAdded(NodeInterface $node)
     {
         if (self::hasReplicationConfiguration($node) && self::nodeReplicationEnabled($node)) {
-            if (self::nodeCreateHiddenEnabled($node)) {
-                self::getNodeReplicator()->replicateNode($node, $createHidden=true);
-            }else {
-                self::getNodeReplicator()->replicateNode($node);
-            }
-        }
+                self::getNodeReplicator()->replicateNode($node, self::nodeCreateHiddenEnabled($node));
     }
 
     /**

--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -20,7 +20,11 @@ class NodeSignalInterceptor
     public static function nodeAdded(NodeInterface $node)
     {
         if (self::hasReplicationConfiguration($node) && self::nodeReplicationEnabled($node)) {
-            self::getNodeReplicator()->replicateNode($node);
+            if (self::nodeCreateHiddenEnabled($node)) {
+                self::getNodeReplicator()->replicateNode($node, $createHidden=true);
+            }else {
+                self::getNodeReplicator()->replicateNode($node);
+            }
         }
     }
 
@@ -66,6 +70,15 @@ class NodeSignalInterceptor
     protected static function nodeReplicationEnabled(NodeInterface $node): bool
     {
         return $node->getNodeType()->hasConfiguration('options.replication.structure') && $node->getNodeType()->getConfiguration('options.replication.structure');
+    }
+
+    /**
+     * @param NodeInterface $node
+     * @return bool
+     */
+    protected static function nodeCreateHiddenEnabled(NodeInterface $node): bool
+    {
+        return $node->getNodeType()->hasConfiguration('options.replication.createHidden') && $node->getNodeType()->getConfiguration('options.replication.createHidden');
     }
 
     /**

--- a/Classes/Replicator/NodeReplicator.php
+++ b/Classes/Replicator/NodeReplicator.php
@@ -44,9 +44,7 @@ class NodeReplicator
             $nodeVariant = $parentVariant->getContext()->adoptNode($node);
 
             // Create replicated node as "hidden node"
-            if($createHidden){
-                $nodeVariant->setHidden(true);
-            }
+                $nodeVariant->setHidden($createHidden);
 
             $this->logReplicationAction($nodeVariant, 'Node was replicated to target context.', __METHOD__);
         }

--- a/Classes/Replicator/NodeReplicator.php
+++ b/Classes/Replicator/NodeReplicator.php
@@ -28,12 +28,6 @@ class NodeReplicator
     protected $logger;
 
     /**
-     * @Flow\Inject
-     * @var PersistenceManagerInterface
-     */
-    protected $persistenceManager;
-
-    /**
      * Replicates a node to all target dimensions where the parent node already exists
      *
      * @param NodeInterface $node

--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,7 @@ This package provides an additional option for the NodeType configuration to aut
 | replication.structure                   | Automatically create and remove the node in other dimensions                    |
 | replication.content                     | Automatically update the content of the corresponding nodes in other dimensions |
 | replication.updateEmptyPropertiesOnly   | When updating content, only update empty properties                             |
+| replication.createHidden                | Replicated nodes are created as hidden nodes                                    |
 
 **Example Configuration:**
 
@@ -54,5 +55,17 @@ This package provides an additional option for the NodeType configuration to aut
       structure: true
       content: true
       updateEmptyPropertiesOnly: true
-    
+      
+      
+'Vendor.Package:TranslateableCategory':
+  superTypes:
+    'Neos.Neos:Content': true
+  ...
+
+  options:
+    replication:
+      structure: true
+      content: true
+      updateEmptyPropertiesOnly: true
+      createHidden: true
 ```


### PR DESCRIPTION
As already described [here](https://github.com/punktDe/nodereplicator/issues/8) this PR adds a new Option `options.createHidden: true` which will replicate nodes as hidden nodes. 

```
  options:
    replication:
      structure: true
      content: true
      updateEmptyPropertiesOnly: true
      
      # NEW OPTION
      createHidden: true
```