### PR TITLE
FEATURE: Allow exclusion of properties from replication

### DIFF
--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -34,7 +34,7 @@ class NodeSignalInterceptor
             if (self::nodeContentUpdateOnlyEmpty($node)) {
                 self::getNodeReplicator()->similarizePropertiesEmptyInOtherDimensions($node);
             } else {
-                self::getNodeReplicator()->similarizeNodeVariants($node);
+                self::getNodeReplicator()->similarizeNodeVariants($node, self::getExcludedProperties($node));
             }
 
         }
@@ -103,4 +103,14 @@ class NodeSignalInterceptor
     {
         return new Replicator\NodeReplicator();
     }
+
+    /**
+     * @param NodeInterface $node
+     * @return array|null
+     */
+    protected static function getExcludedProperties(NodeInterface $node): ?array
+    {
+        return $node->getNodeType()->getConfiguration('options.replication.excludeProperties');
+    }
+
 }

--- a/Classes/Replicator/NodeReplicator.php
+++ b/Classes/Replicator/NodeReplicator.php
@@ -154,25 +154,29 @@ class NodeReplicator
      */
     protected function getExcludedPropertyValues(NodeInterface $nodeVariant, ?array $excludedProperties): array
     {
-        $excludedPropertyValues = [];
-        if ($excludedProperties) {
-            foreach ($excludedProperties as $property) {
-                $excludedPropertyValues[$property] = $nodeVariant->getProperty($property);
-            }
+        if (empty($excludedPropertyValues)) {
+            return [];
         }
+
+        foreach ($excludedProperties as $property) {
+            $excludedPropertyValues[$property] = $nodeVariant->getProperty($property);
+        }
+
         return $excludedPropertyValues;
     }
 
     /**
      * @param NodeInterface $nodeVariant
-     * @param array $excludedPropertyValues
+     * @param array|null $excludedPropertyValues
      */
-    protected function setExcludedPropertyValues(NodeInterface $nodeVariant, array $excludedPropertyValues): void
+    protected function setExcludedPropertyValues(NodeInterface $nodeVariant, ?array $excludedPropertyValues): void
     {
-        if ($excludedPropertyValues) {
-            foreach ($excludedPropertyValues as $property => $value) {
-                $nodeVariant->setProperty($property, $value);
-            }
+        if (empty($excludedPropertyValues)) {
+            return;
+        }
+
+        foreach ($excludedPropertyValues as $property => $value) {
+            $nodeVariant->setProperty($property, $value);
         }
     }
 }

--- a/Classes/Replicator/NodeReplicator.php
+++ b/Classes/Replicator/NodeReplicator.php
@@ -54,8 +54,9 @@ class NodeReplicator
      * Similarize the node to all target dimensions. Copying over all properties and their values.
      *
      * @param NodeInterface $node
+     * @param array|null $excludedProperties
      */
-    public function similarizeNodeVariants(NodeInterface $node): void
+    public function similarizeNodeVariants(NodeInterface $node, ?array $excludedProperties): void
     {
         /** @var NodeInterface $parentVariant */
         foreach ($this->getParentVariants($node) as $parentVariant) {
@@ -66,7 +67,13 @@ class NodeReplicator
                 continue;
             }
 
+            // if properties are excluded from the replication, we store their values before similarizing
+            // and set them back to their original values after
+            $excludedPropertyValues = $this->getExcludedPropertyValues($nodeVariant, $excludedProperties);
+
             $nodeVariant->getNodeData()->similarize($node->getNodeData());
+
+            $this->setExcludedPropertyValues($nodeVariant, $excludedPropertyValues);
 
             $this->logReplicationAction($nodeVariant, 'Content of target node was updated.', __METHOD__);
         }
@@ -137,5 +144,35 @@ class NodeReplicator
         $dimensionString = implode('|', $dimensionsAndPresets);
 
         $this->logger->log($logLevel, sprintf('[NodeIdentifier: %s, TargetDimension: %s] %s', $nodeVariant->getIdentifier(), $dimensionString, $message), LogEnvironment::fromMethodName($loggingMethod ?? __METHOD__));
+    }
+
+    /**
+     * @param NodeInterface $nodeVariant
+     * @param array|null $excludedProperties
+     * @return array
+     * @throws NodeException
+     */
+    protected function getExcludedPropertyValues(NodeInterface $nodeVariant, ?array $excludedProperties): array
+    {
+        $excludedPropertyValues = [];
+        if ($excludedProperties) {
+            foreach ($excludedProperties as $property) {
+                $excludedPropertyValues[$property] = $nodeVariant->getProperty($property);
+            }
+        }
+        return $excludedPropertyValues;
+    }
+
+    /**
+     * @param NodeInterface $nodeVariant
+     * @param array $excludedPropertyValues
+     */
+    protected function setExcludedPropertyValues(NodeInterface $nodeVariant, array $excludedPropertyValues): void
+    {
+        if ($excludedPropertyValues) {
+            foreach ($excludedPropertyValues as $property => $value) {
+                $nodeVariant->setProperty($property, $value);
+            }
+        }
     }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ This package provides an additional option for the NodeType configuration to aut
 | replication.content                     | Automatically update the content of the corresponding nodes in other dimensions |
 | replication.updateEmptyPropertiesOnly   | When updating content, only update empty properties                             |
 | replication.createHidden                | Replicated nodes are created as hidden nodes                                    |
-| replication.excludeProperties           | Exclude properties from replication                                             |
+| replication.excludeProperties           | Do not update values of these properties in the target node                        |
 
 **Example Configuration:**
 

--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,7 @@ This package provides an additional option for the NodeType configuration to aut
 | replication.content                     | Automatically update the content of the corresponding nodes in other dimensions |
 | replication.updateEmptyPropertiesOnly   | When updating content, only update empty properties                             |
 | replication.createHidden                | Replicated nodes are created as hidden nodes                                    |
+| replication.excludeProperties           | Exclude properties from replication                                             |
 
 **Example Configuration:**
 
@@ -68,4 +69,17 @@ This package provides an additional option for the NodeType configuration to aut
       content: true
       updateEmptyPropertiesOnly: true
       createHidden: true
+    
+'Vendor.Package:YetAnotherAddressCategory':
+  superTypes:
+    'Neos.Neos:Content': true
+  ...
+  
+  options:  
+    replication:
+      structure: true
+      content: true
+      excludeProperties:
+        - metaDescription
+        - metaKeywords
 ```


### PR DESCRIPTION
We use the NodeReplicator package in a project but needed to exclude specific properties from being replicated/snyched in other dimensions. As explained in the readme file, I've added a new config option to allow exactly this.
If properties are specified in this option we store their values before the `similarize()` and afterwards set them back to their original values.