### PR TITLE
BUGFIX: Fix wrong empty check in exclude properties feature

### DIFF
--- a/Classes/Replicator/NodeReplicator.php
+++ b/Classes/Replicator/NodeReplicator.php
@@ -154,7 +154,7 @@ class NodeReplicator
      */
     protected function getExcludedPropertyValues(NodeInterface $nodeVariant, ?array $excludedProperties): array
     {
-        if (empty($excludedPropertyValues)) {
+        if (empty($excludedProperties)) {
             return [];
         }
 


### PR DESCRIPTION
While restructuring the code for my last PR as suggested I made a small careless mistake (checking the wrong value for early return) which stopped the exclusion feature from working. Sorry for the extra work!