### PR TITLE
BUGFIX: catch edge case for autocreated child nodes while copying document to other dimension

### DIFF
--- a/Classes/Replicator/NodeReplicator.php
+++ b/Classes/Replicator/NodeReplicator.php
@@ -127,6 +127,14 @@ class NodeReplicator
      */
     protected function getParentVariants(NodeInterface $node): array
     {
+        // This is a fix for an edge case: copying a document with a content collection to another dimension (both using the replication)
+        // with an autocreated child node in the content collection. As the content collection in the new dimension is not persisted at
+        // this point, getParent() on the autocreated child node will return null. As this only happens when copying a document to another
+        // dimension, there is no need to replicate anything in this moment.
+        if ($node->getParent() === null) {
+            return [];
+        }
+        
         return $node->getParent()->getOtherNodeVariants();
     }
 


### PR DESCRIPTION
This is a fix for an edge case. We had a document using the replication for content that had an autocreated child node (content collection) using the replication for structure & content. The content collection had an autocreated child node as well. When copying the document to another dimension the content collection would have been autocreated but not yet persisted, so `getParent()` would be `null` here and calling `getOtherNodeVariants()` on it would provoke an error. As this only happens when copying a document to another dimension, there is no need to (additionally) replicate anything in this moment.

I'm not completely sure if this could have unwanted consequences in other situations, but maybe someone else has more insights on this.