### PR TITLE
BUGFIX: Fix creating nodes with autocreated childnodes

### DIFF
--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -20,6 +20,8 @@ class NodeSignalInterceptor
     public static function nodeAdded(NodeInterface $node): void
     {
         if (self::hasReplicationConfiguration($node) && (self::nodeCreateReplicationEnabled($node) || self::nodeCreateHiddenEnabled($node))) {
+            // The nodedAdded signal is called twice. When it is called the first time, 
+            // the node is not created completely (the child nodes are not created yet), so we skip that call.
             if (count($node->getNodeType()->getAutoCreatedChildNodes()) > 0 && count($node->findChildNodes()) === 0) {
                 return;
             }

--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -20,6 +20,9 @@ class NodeSignalInterceptor
     public static function nodeAdded(NodeInterface $node): void
     {
         if (self::hasReplicationConfiguration($node) && (self::nodeCreateReplicationEnabled($node) || self::nodeCreateHiddenEnabled($node))) {
+            if (count($node->getNodeType()->getAutoCreatedChildNodes()) > 0 && count($node->findChildNodes()) === 0) {
+                return;
+            }
             self::getNodeReplicator()->createNodeVariants($node, self::nodeCreateHiddenEnabled($node));
         }
     }


### PR DESCRIPTION
Current Problem: Replication of site with autocreated childnodes (e.g. "main") does not work properly, the childnodes will not be created in other languages. The problem lies that "nodeAdded" is emitted in createNode- and createSingleNode-function, but the createNode-function calls the createSingleNode-function at the beginning. That is why the site will be replicated and the autocreated childnodes not.

This will fix it by creating the nodeVariants only if the node has children (if the nodeType has any autocreated childnodes).