### PR TITLE
[TASK] Allow nodeRemoved and nodeAdded functions to be called statically

### DIFF
--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -29,14 +29,14 @@ class NodeSignalInterceptor
         }
     }
 
-    public function nodeRemoved(NodeInterface $node): void
+    public static function nodeRemoved(NodeInterface $node): void
     {
         if (self::hasReplicationConfiguration($node) && self::nodeRemoveReplicationEnabled($node)) {
             self::getNodeReplicator()->removeNodeVariants($node);
         }
     }
 
-    public function nodePropertyChanged(NodeInterface $node, string $propertyName, $oldValue, $newValue): void
+    public static function nodePropertyChanged(NodeInterface $node, string $propertyName, $oldValue, $newValue): void
     {
         if (!self::hasReplicationConfiguration($node)) {
             return;


### PR DESCRIPTION
In Package.php methods of the NodeSignalInterceptor class get called as static functions:
`$dispatcher->connect(Node::class, 'nodeAdded', NodeSignalInterceptor::class, '::nodeAdded');`
`$dispatcher->connect(Node::class, 'nodePropertyChanged', NodeSignalInterceptor::class, '::nodePropertyChanged');`
`$dispatcher->connect(Node::class, 'nodeRemoved', NodeSignalInterceptor::class, '::nodeRemoved');`

Without this change:
on PHP >= 8 an Error will occur if a node is removed, or properties are updated:
`Exception in line 186 of /var/www/html/Packages/Framework/Neos.Flow/Classes/SignalSlot/Dispatcher.php: call_user_func_array(): Argument #1 ($callback) must be a valid callback, non-static method PunktDe\NodeReplicator\NodeSignalInterceptor::nodePropertyChanged() cannot be called statically`
With PHP 8 callables have to be a valid callback, non-static methods. 
https://php.watch/versions/8.0/non-static-static-call-fatal-error

This change adapts to that, 
by just declaring the two remaining methods "nodeRemoved" and "nodePropertyChanged" as static as well.

I haven't testet this on PHP < 8.1, however I expect this just to work as the other functions called in `NodeSignalInterceptor` (nodeAdded) already work fine as `static` function.

