### PR TITLE
FEATURE: add option to only replicate nodes with certain starting paths

### DIFF
--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -19,8 +19,8 @@ class NodeSignalInterceptor
      */
     public static function nodeAdded(NodeInterface $node): void
     {
-        if (self::hasReplicationConfiguration($node) && (self::nodeCreateReplicationEnabled($node) || self::nodeCreateHiddenEnabled($node))) {
-            // The nodedAdded signal is called twice. When it is called the first time, 
+        if (self::hasReplicationConfiguration($node) && (self::nodeCreateReplicationEnabled($node) || self::nodeCreateHiddenEnabled($node)) && self::nodeHasAllowedPath($node)) {
+            // The nodedAdded signal is called twice. When it is called the first time,
             // the node is not created completely (the child nodes are not created yet), so we skip that call.
             if (count($node->getNodeType()->getAutoCreatedChildNodes()) > 0 && count($node->findChildNodes()) === 0) {
                 return;
@@ -31,14 +31,14 @@ class NodeSignalInterceptor
 
     public static function nodeRemoved(NodeInterface $node): void
     {
-        if (self::hasReplicationConfiguration($node) && self::nodeRemoveReplicationEnabled($node)) {
+        if (self::hasReplicationConfiguration($node) && self::nodeRemoveReplicationEnabled($node) && self::nodeHasAllowedPath($node)) {
             self::getNodeReplicator()->removeNodeVariants($node);
         }
     }
 
     public static function nodePropertyChanged(NodeInterface $node, string $propertyName, $oldValue, $newValue): void
     {
-        if (!self::hasReplicationConfiguration($node)) {
+        if (!self::hasReplicationConfiguration($node) || !self::nodeHasAllowedPath($node)) {
             return;
         }
 
@@ -70,6 +70,26 @@ class NodeSignalInterceptor
     protected static function nodeCreateHiddenEnabled(NodeInterface $node): bool
     {
         return $node->getNodeType()->hasConfiguration('options.replication.structure.createHidden') && $node->getNodeType()->getConfiguration('options.replication.structure.createHidden');
+    }
+
+    protected static function nodeHasAllowedPath(NodeInterface $node): bool
+    {
+        if (!$node->getNodeType()->hasConfiguration('options.replication.onlyPathsStartingWith')) {
+            return true;  // if not configured, return default: allowed = true
+        }
+
+        $allowedStartingPaths = $node->getNodeType()->getConfiguration('options.replication.onlyPathsStartingWith');
+        if (!is_array($allowedStartingPaths)) {  // fallback if only a string, instead of list was provided in the yaml
+            $allowedStartingPaths = [$allowedStartingPaths];
+        }
+        $nodePath = strval($node->findNodePath());
+
+        foreach ($allowedStartingPaths as $allowedPath) {
+            if (substr($nodePath, 0, strlen($allowedPath)) === $allowedPath) {  // str_starts_with for pre php 8
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,10 @@ This package provides an additional option for the NodeType configuration to aut
             
             // default false, takes precedence of update
             updateEmptyOnly: true 
+          
+          // by default all paths are allowed, with this option set the replication is limited to nodes whose path starts with one of the defined values
+          onlyPathsStartingWith:
+            - /sites/yourSite/childNodeOfRootPage
     
        properties:
          myProperty:


### PR DESCRIPTION
Hi,

we have a use-case, where we only want to replicate content in certain sub-trees of the node tree.

For this we added an option to limit replication to only nodes 
which have paths starting with one of the option`s values.

Maybe this could be useful for other people as well.