### PR TITLE
FIX: Endlessly deleting node

### DIFF
--- a/Classes/Replicator/NodeReplicator.php
+++ b/Classes/Replicator/NodeReplicator.php
@@ -52,7 +52,7 @@ class NodeReplicator
     {
         foreach ($this->getParentVariants($node) as $parentVariant) {
             $nodeVariant = $parentVariant->getContext()->getNodeByIdentifier($node->getIdentifier());
-            if ($nodeVariant !== null) {
+            if ($nodeVariant !== null && !$nodeVariant->isRemoved()) {
                 $nodeVariant->remove();
                 $this->logReplicationAction($nodeVariant, 'Node variant was removed.', __METHOD__);
             }


### PR DESCRIPTION
When deleting a whole structure with multiple nodes that are replicated across dimensions, an endless loop can occur. 
The deleted node retriggers deletion and thus leads to an endless loop of elements being deleted. 
