### PR TITLE
BUGFIX: prevent endless loop while deleting nodes

### DIFF
--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -10,7 +10,6 @@ namespace PunktDe\NodeReplicator;
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Exception\NodeException;
-use Psr\Log\LoggerInterface;
 use PunktDe\NodeReplicator\Replicator\NodeReplicator;
 
 class NodeSignalInterceptor

--- a/Classes/Replicator/NodeReplicator.php
+++ b/Classes/Replicator/NodeReplicator.php
@@ -15,6 +15,7 @@ use Neos\Flow\Log\Utility\LogEnvironment;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use PunktDe\NodeReplicator\NodeSignalInterceptor;
 
 /**
  * @Flow\Scope("singleton")
@@ -53,7 +54,7 @@ class NodeReplicator
         foreach ($this->getParentVariants($node) as $parentVariant) {
             $nodeVariant = $parentVariant->getContext()->getNodeByIdentifier($node->getIdentifier());
             if ($nodeVariant !== null) {
-                $nodeVariant->remove();
+                NodeSignalInterceptor::withoutTriggeringSignals(fn() => $nodeVariant->remove());
                 $this->logReplicationAction($nodeVariant, 'Node variant was removed.', __METHOD__);
             }
         }
@@ -91,7 +92,7 @@ class NodeReplicator
         if ($node->getParent() === null) {
             return [];
         }
-        
+
         return $node->getParent()->getOtherNodeVariants();
     }
 


### PR DESCRIPTION
In our case (Neos 8.3), it happened that when a node was deleted, the NodeReplicator activated, which then called $nodeVariant->remove(), which again activated an nodeRemoved signal, which then activated the NodeReplicator with the same node again (etc etc).

I am unsure why we did not catch this earlier (we are using NodeReplicator since quite a long time already).